### PR TITLE
Remove left right references

### DIFF
--- a/project.ipynb
+++ b/project.ipynb
@@ -58,11 +58,11 @@
     "\n",
     "**Projects** allow you to practice and apply the skills you've learned in the DataCamp courses. In each project you carry out an **end-to-end analysis**, on a **real-world task**, using **real-world** tools and workflows. The exception is _this_ project, which is just an introduction to the DataCamp project interface.\n",
     "\n",
-    "On the right, you have a *Jupyter notebook*, a free, open-source web application that is great for interactive data analysis. A DataCamp project consists of a number of _tasks_, and here on the left, you have the task instructions. Your first task is easy:\n",
+    "On the side, you have a *Jupyter notebook*, a free, open-source web application that is great for interactive data analysis. A DataCamp project consists of a number of _tasks_, and here, you have the task instructions. Your first task is easy:\n",
     "\n",
     "<hr>\n",
     "\n",
-    "* Run the code cell on the right to calculate how many children were born per day on average in 2016.\n",
+    "* Run the code cell on the side to calculate how many children were born per day on average in 2016.\n",
     "* Then, click the **Next Task** button below.\n"
    ]
   },
@@ -155,7 +155,7 @@
    "source": [
     "The Jupyter notebook in a DataCamp project will contain an analysis, data exploration, or other *narrative* combining code, data, and text. But, and here is the catch, some of the code is missing, and it's up to you to get it right! Sometimes you will only need to fix small things with the code, but in some projects, you will get to write a whole analysis yourself.\n",
     "\n",
-    "However, in this project you won't have to do much — the notebook on the right is almost complete — there are just some minor issues that you need to deal with:\n",
+    "However, in this project you won't have to do much — the notebook on the side is almost complete — there are just some minor issues that you need to deal with:\n",
     "\n",
     "<hr>\n",
     "\n",
@@ -742,7 +742,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/project.ipynb
+++ b/project.ipynb
@@ -1,1 +1,750 @@
-{"cells":[{"cell_type":"markdown","metadata":{},"source":["# Introduction to DataCamp Projects"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true},"outputs":[],"source":["# Setup code\n","%load_ext ipython_nose"]},{"cell_type":"markdown","metadata":{"tags":["type:NotebookTask","key: 8c3ba502e2"]},"source":["## 1. This is a Jupyter notebook!"]},{"cell_type":"markdown","metadata":{"tags":["@context"]},"source":["A *Jupyter notebook* is a document that contains text cells (what you're reading right now) and code cells. What is special with a notebook is that it's _interactive_: You can change or add code cells, and then _run_ a cell by first selecting it and then clicking the _run cell_ button above ( **▶|** Run ) or hitting `ctrl + enter`. \n","\n","![](https://s3.amazonaws.com/assets.datacamp.com/production/project_33/datasets/run_code_cell_image.png)\n","\n","The result will be displayed directly in the notebook. You _could_ use a notebook as a simple calculator. For example, it's estimated that on average 256 children were born every minute in 2016. The code cell below calculates how many children were born on average on a day. "]},{"cell_type":"markdown","metadata":{"tags":["@instructions"]},"source":["#### This is a DataCamp project!\n","\n","**Projects** allow you to practice and apply the skills you've learned in the DataCamp courses. In each project you carry out an **end-to-end analysis**, on a **real-world task**, using **real-world** tools and workflows. The exception is _this_ project, which is just an introduction to the DataCamp project interface.\n","\n","On the right, you have a *Jupyter notebook*, a free, open-source web application that is great for interactive data analysis. A DataCamp project consists of a number of _tasks_, and here on the left, you have the task instructions. Your first task is easy:\n","\n","\u003chr\u003e\n","\n","* Run the code cell on the right to calculate how many children were born per day on average in 2016.\n","* Then, click the **Next Task** button below.\n"]},{"cell_type":"markdown","metadata":{"tags":["@hint"]},"source":["Normally a project task can be tricky, and here you would find a hint that would help you. But in this task, you just need to run the cell."]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@sample_code"]},"outputs":[],"source":["# I'm a code cell, click me, then run me!\n","256 * 60 * 24 # Children × minutes × hours"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@solution"]},"outputs":[],"source":["# I'm a code cell, click me, then run me!\n","256 * 60 * 24 # Children × minutes × hours"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@tests"]},"outputs":[],"source":["%%nose\n","# No tests"]},{"cell_type":"markdown","metadata":{"tags":["type:NotebookTask","key: b5ed313abb"]},"source":["## 2. Put _any_ code in code cells"]},{"cell_type":"markdown","metadata":{"tags":["@context"]},"source":["But a code cell can contain much more than a simple one-liner! This is a notebook running python and you can put _any_ python code in a code cell (but notebooks can run other languages too, like R). Below is a code cell where we define a whole new function (`greet`). To show the output of `greet` we run it last in the code cell as the last value is always printed out. "]},{"cell_type":"markdown","metadata":{"tags":["@instructions"]},"source":["The Jupyter notebook in a DataCamp project will contain an analysis, data exploration, or other *narrative* combining code, data, and text. But, and here is the catch, some of the code is missing, and it's up to you to get it right! Sometimes you will only need to fix small things with the code, but in some projects, you will get to write a whole analysis yourself.\n","\n","However, in this project you won't have to do much — the notebook on the right is almost complete — there are just some minor issues that you need to deal with:\n","\n","\u003chr\u003e\n","\n","* Replace the arguments to `greet('James', 'Bond')` with your own name.\n","* Run the code cell. (As this is part of every task we will drop this instruction from now on.)"]},{"cell_type":"markdown","metadata":{"tags":["@hint"]},"source":["Normally a project task can be tricky, and here you would find a hint that would help you. But in this task, you just need to replace `'James', 'Bond'` with your name and run the cell."]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@sample_code"]},"outputs":[],"source":["def greet(first_name, last_name):\n","    greeting = 'My name is ' + last_name + ', ' + first_name + ' ' + last_name + '!'\n","    return greeting\n","\n","# Replace with your first and last name.\n","# That is, unless your name is already James Bond.\n","greet('James', 'Bond')"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@solution"]},"outputs":[],"source":["def greet(first_name, last_name):\n","    greeting = 'My name is ' + last_name + ', ' + first_name + ' ' + last_name + '!'\n","    return greeting\n","\n","# Replace with your first and last name.\n","# That is, unless your name is already James Bond.\n","greet('Sean', 'Connery')"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@tests"]},"outputs":[],"source":["%%nose\n","# No tests"]},{"cell_type":"markdown","metadata":{"tags":["type:NotebookTask","key: d71cd3b937"]},"source":["## 3. Jupyter notebooks ♡ data "]},{"cell_type":"markdown","metadata":{"tags":["@context"]},"source":["We've seen that notebooks can display basic objects such as numbers and strings. But notebooks also support the objects used in data science, which makes them great for interactive data analysis!\n","\n","For example, below we create a `pandas` DataFrame by reading in a `csv`-file with the average global temperature for the years 1850 to 2016. If we look at the `head` of this DataFrame the notebook will render it as a nice-looking table."]},{"cell_type":"markdown","metadata":{"tags":["@instructions"]},"source":["* Read in the dataset `datasets/global_temperature.csv` and take a look at the first couple of rows \n","\n","\u003chr\u003e\n","\n","The list of instructions for this task are now listed at the top — that's where you'll usually find them in DataCamp projects. Below the list of instructions (that is, **right here**) you will find more information that will help you solve the task. For example:\n","\n","This task requires you to write a single line of python code. It should replace the comment that says `# ... YOUR CODE FOR TASK 3 ...` .\n","\n","If you still feel at a loss as to what to do you can always click the **hint** below."]},{"cell_type":"markdown","metadata":{"tags":["@hint"]},"source":["If `df` is a `pandas` DataFrame then the following gives you the first couple of rows:\n","\n","```python\n","df.head()\n","```"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@sample_code"]},"outputs":[],"source":["# Importing the pandas module\n","import pandas as pd\n","\n","# Reading in the global temperature data,data\n","global_temp = pd.read_csv('datasets/global_temperature.csv')\n","\n","# Take a look at the first datapoints\n","# ... YOUR CODE FOR TASK 3 ..."]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"scrolled":true,"tags":["@solution"]},"outputs":[],"source":["# Importing the pandas module\n","import pandas as pd\n","\n","# Reading in the global temperature data,data\n","global_temp = pd.read_csv('datasets/global_temperature.csv')\n","\n","# Take a look at the first datapoints\n","global_temp.head()"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@tests"]},"outputs":[],"source":["%%nose\n","# No tests"]},{"cell_type":"markdown","metadata":{"tags":["type:NotebookTask","key: 4c4219b8e7"]},"source":["## 4. Jupyter notebooks ♡ plots "]},{"cell_type":"markdown","metadata":{"tags":["@context"]},"source":["Tables are nice but — as the saying goes — _\"a plot can show a thousand data points\"_. Notebooks handle plots as well, but it requires a bit of magic. Here _magic_ does not refer to any arcane rituals but to so-called \"magic commands\" that affect how the Jupyter notebook works. Magic commands start with either `%` or `%%` and the command we need to nicely display plots inline is `%matplotlib inline`. With this *magic* in place, all plots created in code cells will automatically be displayed inline. \n","\n","Let's take a look at the global temperature for the last 150 years."]},{"cell_type":"markdown","metadata":{"tags":["@instructions"]},"source":["* Add any suitable labels to the x-axis and y-axis of the plot.\n","\n","\u003chr\u003e\n","\n","A triple dot `...` in a code cell means that something is missing and has to be filled in. \n","\n","As projects is a new addition to DataCamp it might also be the case that *we've* missed something. If you get any problems with the interface or notice any bugs, please **Report an Issue** by clicking the link in the top right corner."]},{"cell_type":"markdown","metadata":{"tags":["@hint"]},"source":["Replace `'...'` with any suitable labels. For example: `'Year'` and `'Degrees Celsius'`."]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"scrolled":true,"tags":["@sample_code"]},"outputs":[],"source":["# Setting up inline plotting using jupyter notebook \"magic\"\n","%matplotlib inline\n","\n","import matplotlib.pyplot as plt\n","\n","# Plotting global temperature in degrees celsius by year.\n","plt.plot(global_temp['year'], global_temp['degrees_celsius'])\n","\n","# Adding some nice labels \n","plt.xlabel('...') \n","plt.ylabel('...') "]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"scrolled":true,"tags":["@solution"]},"outputs":[],"source":["# Make sure plots appear inline\n","%matplotlib inline\n","\n","import matplotlib.pyplot as plt\n","\n","# Plotting global temperature in degrees celsius by year.\n","plt.plot(global_temp['year'], global_temp['degrees_celsius'])\n","\n","# Add some nice labels and show the plot\n","plt.xlabel('Year')\n","plt.ylabel('Degrees Celsius')"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@tests"]},"outputs":[],"source":["%%nose\n","# No tests"]},{"cell_type":"markdown","metadata":{"tags":["type:NotebookTask","key: 1df3b07b44"]},"source":["## 5. Jupyter notebooks ♡ a lot more "]},{"cell_type":"markdown","metadata":{"tags":["@context"]},"source":["Tables and plots are the most common outputs when doing data analysis, but Jupyter notebooks can render many more types of outputs such as sound, animation, video, etc. Yes, almost anything that can be shown in a modern web browser. This also makes it possible to include _interactive widgets_ directly in the notebook!\n","\n","For example, this (slightly complicated) code will create an interactive map showing the locations of the three largest smartphone companies in 2016. You can move and zoom the map, and you can click the markers for more info! "]},{"cell_type":"markdown","metadata":{"tags":["@instructions"]},"source":["* Change the `label` strings in `companies` so that they include the market share percentage (replace the `...`).\n","\n","\u003chr\u003e\n","\n","Wait! Before you complete this task try to *check* your project by clicking the **Check Project** button. This will go through all the tasks and check which are complete. For a correct task, the task circle will turn green and when something needs to be fixed the task circle will turn orange. You can then get more information about what needs to be done at the bottom of the orange tasks. You can check a project at any time to see how far you've gotten.\n","\n","But here is the information you need to solve *this* task; the 2016 market share of the top three smartphone companies:\n","\n","* Samsung: 20.5%\n","* Apple: 14.4%\n","* Huawei: 8.9%"]},{"cell_type":"markdown","metadata":{"tags":["@hint"]},"source":["The first label should be `'Samsung: 20.5%'` ."]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@sample_code"]},"outputs":[],"source":["# Making a map using the folium module\n","import folium\n","phone_map = folium.Map()\n","\n","# Top three smart phone companies by market share in 2016.\n","companies = [\n","    {'loc': [37.4970,  127.0266], 'label': 'Samsung: ...%'},\n","    {'loc': [37.3318, -122.0311], 'label': 'Apple: ...%'},\n","    {'loc': [22.5431,  114.0579], 'label': 'Huawei: ...%'}] \n","\n","# Adding markers to the map.\n","for company in companies:\n","    marker = folium.Marker(location=company['loc'], popup=company['label'])\n","    marker.add_to(phone_map)\n","\n","# The last object in the cell always gets shown in the notebook\n","phone_map"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@solution"]},"outputs":[],"source":["# Making a map using the folium module\n","import folium\n","phone_map = folium.Map()\n","\n","# Top three smart phone companies by market share in 2016.\n","companies = [\n","    {'loc': [37.4970,  127.0266], 'label': 'Samsung: 20.5%'},\n","    {'loc': [37.3318, -122.0311], 'label': 'Apple: 14.4%'},\n","    {'loc': [22.5431,  114.0579], 'label': 'Huawei: 8.9%'}] \n","\n","# Adding markers to the map.\n","for company in companies:\n","    marker = folium.Marker(location=company['loc'], popup=company['label'])\n","    marker.add_to(phone_map)\n","\n","# The last object in the cell always gets shown in the notebook\n","phone_map"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@tests"]},"outputs":[],"source":["%%nose\n","\n","def test_market_share_of_samsung():\n","    assert '20.5' in companies[0]['label'], \\\n","        \"The market share of Samsung should be 20.5%\"\n","        \n","def test_market_share_of_apple():\n","    assert '14.4' in companies[1]['label'], \\\n","        \"The market share of Apple should be 14.4%\"\n","\n","def test_market_share_of_huawei():\n","    assert '8.9' in companies[2]['label'], \\\n","        \"The market share of Huawei should be 8.9%\""]},{"cell_type":"markdown","metadata":{"tags":["type:NotebookTask","key: 9ccef156d2"]},"source":["## 6. Goodbye for now! "]},{"cell_type":"markdown","metadata":{"tags":["@context"]},"source":["This was just a short introduction to Jupyter notebooks, an open source technology that is increasingly used for data science and analysis. I hope you enjoyed it! :)"]},{"cell_type":"markdown","metadata":{"tags":["@instructions"]},"source":["And this was just a short introduction to DataCamp projects. I hope you enjoyed it too! You are now ready to get started on your first *real* DataCamp project.\n","\n","\u003chr\u003e\n","\n","* Are you ready to get started with DataCamp projects, `True` or `False`?\n","* Check your project by clicking the **Check Project** button!\n","\n","\u003chr\u003e\n","\n","\n","If you want to know more about how Jupyter notebooks work, and maybe even want to install them on your own computer, check out \u003ca href=\"https://www.datacamp.com/community/tutorials/tutorial-jupyter-notebook\" target=\"_blank\"\u003ethis tutorial on DataCamp community\u003c/a\u003e.\n"]},{"cell_type":"markdown","metadata":{"tags":["@hint"]},"source":["Just change the code cell to\n","\n","```\n","I_am_ready = True\n","```\n","\n","I think you are ready!"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@sample_code"]},"outputs":[],"source":["# Are you ready to get started with  DataCamp projects?\n","I_am_ready = False\n","\n","# Ps. \n","# Feel free to try out any other stuff in this notebook. \n","# It's all yours!"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@solution"]},"outputs":[],"source":["# Are you ready to get started with projects?\n","I_am_ready = True\n","\n","# Ps. \n","# Feel free to try out any other stuff in this notebook. \n","# It's all yours!"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true,"tags":["@tests"]},"outputs":[],"source":["%%nose\n","\n","def test_if_ready():\n","    assert I_am_ready, \\\n","        \"I_am_ready should be set to True, if you are ready to get started with DataCamp projects, that is.\""]}],"metadata":{"celltoolbar":"Tags","kernelspec":{"display_name":"Python 3","language":"python","name":"python3"},"language_info":{"codemirror_mode":{"name":"ipython","version":3},"file_extension":".py","mimetype":"text/x-python","name":"python","nbconvert_exporter":"python","pygments_lexer":"ipython3","version":"3.6.2"}},"nbformat":4,"nbformat_minor":2}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introduction to DataCamp Projects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Setup code\n",
+    "%load_ext ipython_nose"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "type:NotebookTask",
+     "key: 8c3ba502e2"
+    ]
+   },
+   "source": [
+    "## 1. This is a Jupyter notebook!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@context"
+    ]
+   },
+   "source": [
+    "A *Jupyter notebook* is a document that contains text cells (what you're reading right now) and code cells. What is special with a notebook is that it's _interactive_: You can change or add code cells, and then _run_ a cell by first selecting it and then clicking the _run cell_ button above ( **▶|** Run ) or hitting `ctrl + enter`. \n",
+    "\n",
+    "![](https://s3.amazonaws.com/assets.datacamp.com/production/project_33/datasets/run_code_cell_image.png)\n",
+    "\n",
+    "The result will be displayed directly in the notebook. You _could_ use a notebook as a simple calculator. For example, it's estimated that on average 256 children were born every minute in 2016. The code cell below calculates how many children were born on average on a day. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@instructions"
+    ]
+   },
+   "source": [
+    "#### This is a DataCamp project!\n",
+    "\n",
+    "**Projects** allow you to practice and apply the skills you've learned in the DataCamp courses. In each project you carry out an **end-to-end analysis**, on a **real-world task**, using **real-world** tools and workflows. The exception is _this_ project, which is just an introduction to the DataCamp project interface.\n",
+    "\n",
+    "On the right, you have a *Jupyter notebook*, a free, open-source web application that is great for interactive data analysis. A DataCamp project consists of a number of _tasks_, and here on the left, you have the task instructions. Your first task is easy:\n",
+    "\n",
+    "<hr>\n",
+    "\n",
+    "* Run the code cell on the right to calculate how many children were born per day on average in 2016.\n",
+    "* Then, click the **Next Task** button below.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@hint"
+    ]
+   },
+   "source": [
+    "Normally a project task can be tricky, and here you would find a hint that would help you. But in this task, you just need to run the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@sample_code"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# I'm a code cell, click me, then run me!\n",
+    "256 * 60 * 24 # Children × minutes × hours"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@solution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# I'm a code cell, click me, then run me!\n",
+    "256 * 60 * 24 # Children × minutes × hours"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@tests"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%nose\n",
+    "# No tests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "type:NotebookTask",
+     "key: b5ed313abb"
+    ]
+   },
+   "source": [
+    "## 2. Put _any_ code in code cells"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@context"
+    ]
+   },
+   "source": [
+    "But a code cell can contain much more than a simple one-liner! This is a notebook running python and you can put _any_ python code in a code cell (but notebooks can run other languages too, like R). Below is a code cell where we define a whole new function (`greet`). To show the output of `greet` we run it last in the code cell as the last value is always printed out. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@instructions"
+    ]
+   },
+   "source": [
+    "The Jupyter notebook in a DataCamp project will contain an analysis, data exploration, or other *narrative* combining code, data, and text. But, and here is the catch, some of the code is missing, and it's up to you to get it right! Sometimes you will only need to fix small things with the code, but in some projects, you will get to write a whole analysis yourself.\n",
+    "\n",
+    "However, in this project you won't have to do much — the notebook on the right is almost complete — there are just some minor issues that you need to deal with:\n",
+    "\n",
+    "<hr>\n",
+    "\n",
+    "* Replace the arguments to `greet('James', 'Bond')` with your own name.\n",
+    "* Run the code cell. (As this is part of every task we will drop this instruction from now on.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@hint"
+    ]
+   },
+   "source": [
+    "Normally a project task can be tricky, and here you would find a hint that would help you. But in this task, you just need to replace `'James', 'Bond'` with your name and run the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@sample_code"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def greet(first_name, last_name):\n",
+    "    greeting = 'My name is ' + last_name + ', ' + first_name + ' ' + last_name + '!'\n",
+    "    return greeting\n",
+    "\n",
+    "# Replace with your first and last name.\n",
+    "# That is, unless your name is already James Bond.\n",
+    "greet('James', 'Bond')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@solution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def greet(first_name, last_name):\n",
+    "    greeting = 'My name is ' + last_name + ', ' + first_name + ' ' + last_name + '!'\n",
+    "    return greeting\n",
+    "\n",
+    "# Replace with your first and last name.\n",
+    "# That is, unless your name is already James Bond.\n",
+    "greet('Sean', 'Connery')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@tests"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%nose\n",
+    "# No tests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "type:NotebookTask",
+     "key: d71cd3b937"
+    ]
+   },
+   "source": [
+    "## 3. Jupyter notebooks ♡ data "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@context"
+    ]
+   },
+   "source": [
+    "We've seen that notebooks can display basic objects such as numbers and strings. But notebooks also support the objects used in data science, which makes them great for interactive data analysis!\n",
+    "\n",
+    "For example, below we create a `pandas` DataFrame by reading in a `csv`-file with the average global temperature for the years 1850 to 2016. If we look at the `head` of this DataFrame the notebook will render it as a nice-looking table."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@instructions"
+    ]
+   },
+   "source": [
+    "* Read in the dataset `datasets/global_temperature.csv` and take a look at the first couple of rows \n",
+    "\n",
+    "<hr>\n",
+    "\n",
+    "The list of instructions for this task are now listed at the top — that's where you'll usually find them in DataCamp projects. Below the list of instructions (that is, **right here**) you will find more information that will help you solve the task. For example:\n",
+    "\n",
+    "This task requires you to write a single line of python code. It should replace the comment that says `# ... YOUR CODE FOR TASK 3 ...` .\n",
+    "\n",
+    "If you still feel at a loss as to what to do you can always click the **hint** below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@hint"
+    ]
+   },
+   "source": [
+    "If `df` is a `pandas` DataFrame then the following gives you the first couple of rows:\n",
+    "\n",
+    "```python\n",
+    "df.head()\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@sample_code"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Importing the pandas module\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Reading in the global temperature data,data\n",
+    "global_temp = pd.read_csv('datasets/global_temperature.csv')\n",
+    "\n",
+    "# Take a look at the first datapoints\n",
+    "# ... YOUR CODE FOR TASK 3 ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true,
+    "tags": [
+     "@solution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Importing the pandas module\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Reading in the global temperature data,data\n",
+    "global_temp = pd.read_csv('datasets/global_temperature.csv')\n",
+    "\n",
+    "# Take a look at the first datapoints\n",
+    "global_temp.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@tests"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%nose\n",
+    "# No tests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "type:NotebookTask",
+     "key: 4c4219b8e7"
+    ]
+   },
+   "source": [
+    "## 4. Jupyter notebooks ♡ plots "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@context"
+    ]
+   },
+   "source": [
+    "Tables are nice but — as the saying goes — _\"a plot can show a thousand data points\"_. Notebooks handle plots as well, but it requires a bit of magic. Here _magic_ does not refer to any arcane rituals but to so-called \"magic commands\" that affect how the Jupyter notebook works. Magic commands start with either `%` or `%%` and the command we need to nicely display plots inline is `%matplotlib inline`. With this *magic* in place, all plots created in code cells will automatically be displayed inline. \n",
+    "\n",
+    "Let's take a look at the global temperature for the last 150 years."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@instructions"
+    ]
+   },
+   "source": [
+    "* Add any suitable labels to the x-axis and y-axis of the plot.\n",
+    "\n",
+    "<hr>\n",
+    "\n",
+    "A triple dot `...` in a code cell means that something is missing and has to be filled in. \n",
+    "\n",
+    "As projects is a new addition to DataCamp it might also be the case that *we've* missed something. If you get any problems with the interface or notice any bugs, please **Report an Issue** by clicking the link in the top right corner."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@hint"
+    ]
+   },
+   "source": [
+    "Replace `'...'` with any suitable labels. For example: `'Year'` and `'Degrees Celsius'`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true,
+    "tags": [
+     "@sample_code"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Setting up inline plotting using jupyter notebook \"magic\"\n",
+    "%matplotlib inline\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Plotting global temperature in degrees celsius by year.\n",
+    "plt.plot(global_temp['year'], global_temp['degrees_celsius'])\n",
+    "\n",
+    "# Adding some nice labels \n",
+    "plt.xlabel('...') \n",
+    "plt.ylabel('...') "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true,
+    "tags": [
+     "@solution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Make sure plots appear inline\n",
+    "%matplotlib inline\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Plotting global temperature in degrees celsius by year.\n",
+    "plt.plot(global_temp['year'], global_temp['degrees_celsius'])\n",
+    "\n",
+    "# Add some nice labels and show the plot\n",
+    "plt.xlabel('Year')\n",
+    "plt.ylabel('Degrees Celsius')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@tests"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%nose\n",
+    "# No tests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "type:NotebookTask",
+     "key: 1df3b07b44"
+    ]
+   },
+   "source": [
+    "## 5. Jupyter notebooks ♡ a lot more "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@context"
+    ]
+   },
+   "source": [
+    "Tables and plots are the most common outputs when doing data analysis, but Jupyter notebooks can render many more types of outputs such as sound, animation, video, etc. Yes, almost anything that can be shown in a modern web browser. This also makes it possible to include _interactive widgets_ directly in the notebook!\n",
+    "\n",
+    "For example, this (slightly complicated) code will create an interactive map showing the locations of the three largest smartphone companies in 2016. You can move and zoom the map, and you can click the markers for more info! "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@instructions"
+    ]
+   },
+   "source": [
+    "* Change the `label` strings in `companies` so that they include the market share percentage (replace the `...`).\n",
+    "\n",
+    "<hr>\n",
+    "\n",
+    "Wait! Before you complete this task try to *check* your project by clicking the **Check Project** button. This will go through all the tasks and check which are complete. For a correct task, the task circle will turn green and when something needs to be fixed the task circle will turn orange. You can then get more information about what needs to be done at the bottom of the orange tasks. You can check a project at any time to see how far you've gotten.\n",
+    "\n",
+    "But here is the information you need to solve *this* task; the 2016 market share of the top three smartphone companies:\n",
+    "\n",
+    "* Samsung: 20.5%\n",
+    "* Apple: 14.4%\n",
+    "* Huawei: 8.9%"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@hint"
+    ]
+   },
+   "source": [
+    "The first label should be `'Samsung: 20.5%'` ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@sample_code"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Making a map using the folium module\n",
+    "import folium\n",
+    "phone_map = folium.Map()\n",
+    "\n",
+    "# Top three smart phone companies by market share in 2016.\n",
+    "companies = [\n",
+    "    {'loc': [37.4970,  127.0266], 'label': 'Samsung: ...%'},\n",
+    "    {'loc': [37.3318, -122.0311], 'label': 'Apple: ...%'},\n",
+    "    {'loc': [22.5431,  114.0579], 'label': 'Huawei: ...%'}] \n",
+    "\n",
+    "# Adding markers to the map.\n",
+    "for company in companies:\n",
+    "    marker = folium.Marker(location=company['loc'], popup=company['label'])\n",
+    "    marker.add_to(phone_map)\n",
+    "\n",
+    "# The last object in the cell always gets shown in the notebook\n",
+    "phone_map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@solution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Making a map using the folium module\n",
+    "import folium\n",
+    "phone_map = folium.Map()\n",
+    "\n",
+    "# Top three smart phone companies by market share in 2016.\n",
+    "companies = [\n",
+    "    {'loc': [37.4970,  127.0266], 'label': 'Samsung: 20.5%'},\n",
+    "    {'loc': [37.3318, -122.0311], 'label': 'Apple: 14.4%'},\n",
+    "    {'loc': [22.5431,  114.0579], 'label': 'Huawei: 8.9%'}] \n",
+    "\n",
+    "# Adding markers to the map.\n",
+    "for company in companies:\n",
+    "    marker = folium.Marker(location=company['loc'], popup=company['label'])\n",
+    "    marker.add_to(phone_map)\n",
+    "\n",
+    "# The last object in the cell always gets shown in the notebook\n",
+    "phone_map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@tests"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%nose\n",
+    "\n",
+    "def test_market_share_of_samsung():\n",
+    "    assert '20.5' in companies[0]['label'], \\\n",
+    "        \"The market share of Samsung should be 20.5%\"\n",
+    "        \n",
+    "def test_market_share_of_apple():\n",
+    "    assert '14.4' in companies[1]['label'], \\\n",
+    "        \"The market share of Apple should be 14.4%\"\n",
+    "\n",
+    "def test_market_share_of_huawei():\n",
+    "    assert '8.9' in companies[2]['label'], \\\n",
+    "        \"The market share of Huawei should be 8.9%\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "type:NotebookTask",
+     "key: 9ccef156d2"
+    ]
+   },
+   "source": [
+    "## 6. Goodbye for now! "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@context"
+    ]
+   },
+   "source": [
+    "This was just a short introduction to Jupyter notebooks, an open source technology that is increasingly used for data science and analysis. I hope you enjoyed it! :)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@instructions"
+    ]
+   },
+   "source": [
+    "And this was just a short introduction to DataCamp projects. I hope you enjoyed it too! You are now ready to get started on your first *real* DataCamp project.\n",
+    "\n",
+    "<hr>\n",
+    "\n",
+    "* Are you ready to get started with DataCamp projects, `True` or `False`?\n",
+    "* Check your project by clicking the **Check Project** button!\n",
+    "\n",
+    "<hr>\n",
+    "\n",
+    "\n",
+    "If you want to know more about how Jupyter notebooks work, and maybe even want to install them on your own computer, check out <a href=\"https://www.datacamp.com/community/tutorials/tutorial-jupyter-notebook\" target=\"_blank\">this tutorial on DataCamp community</a>.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": [
+     "@hint"
+    ]
+   },
+   "source": [
+    "Just change the code cell to\n",
+    "\n",
+    "```\n",
+    "I_am_ready = True\n",
+    "```\n",
+    "\n",
+    "I think you are ready!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@sample_code"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Are you ready to get started with  DataCamp projects?\n",
+    "I_am_ready = False\n",
+    "\n",
+    "# Ps. \n",
+    "# Feel free to try out any other stuff in this notebook. \n",
+    "# It's all yours!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@solution"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Are you ready to get started with projects?\n",
+    "I_am_ready = True\n",
+    "\n",
+    "# Ps. \n",
+    "# Feel free to try out any other stuff in this notebook. \n",
+    "# It's all yours!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "@tests"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%nose\n",
+    "\n",
+    "def test_if_ready():\n",
+    "    assert I_am_ready, \\\n",
+    "        \"I_am_ready should be set to True, if you are ready to get started with DataCamp projects, that is.\""
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
We are planning to A/B test switching the position of the Jupyter notebook to the left. This PR removes explicit references to the position of the notebook so it makes sense for both variants.

In order to look at what content changed, I would recommend looking at this [commit](https://github.com/datacamp/projects-basic-introduction-python/commit/9b9bcdc5f9d722c149a23c1425b7f8cb438773fe) since it is cleaner.